### PR TITLE
Fixed issue when more than one message arrive

### DIFF
--- a/companion/manifest.json
+++ b/companion/manifest.json
@@ -3,7 +3,7 @@
 	"name": "presentationtools-aps",
 	"shortname": "aps",
 	"description": "Module to control Auto Presentation Switcher",
-	"version": "2.0.6",
+	"version": "2.1.1",
 	"license": "MIT",
 	"repository": "git+https://github.com/bitfocus/companion-module-presentationtools-aps.git",
 	"bugs": "https://github.com/bitfocus/companion-module-presentationtools-aps/issues",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "presentationtools-aps",
-	"version": "2.1.0",
+	"version": "2.1.1",
 	"main": "index.js",
 	"prettier": "@companion-module/tools/.prettierrc.json",
 	"scripts": {


### PR DESCRIPTION
Issue:
When more than one message received, only the oldest one will always be handled, then `buffer.replace(message + this.delimiter, '')` will remove it. When a new message arrives, the second oldest one will be handled so one message will always be delayed.

Solution:
Changed messages to array and handled it as a queue 